### PR TITLE
Fix testimonial formar in right bar.

### DIFF
--- a/src/shared/components/testimonials/Testimonials.tsx
+++ b/src/shared/components/testimonials/Testimonials.tsx
@@ -100,7 +100,7 @@ export default class Testimonials extends React.Component <{}, {}> {
                 <CSSTransitionGroup transitionName="test-trans" transitionEnterTimeout={2000} transitionLeaveTimeout={2000}>
                     <div className='testimonial-blockquote' key={testimonialIndex}>
                         <p>"{activeTestimonial.quote}"</p>
-                        <cite>--{activeTestimonial.cite}</cite>
+                        <cite>-- {activeTestimonial.cite}</cite>
                     </div>
                 </CSSTransitionGroup>
             </div>


### PR DESCRIPTION
# What? Why?

Add space between dash and speaker's name in testimonials cite.
