### PR TITLE
Duplicate timeline functionality with tooltips

### DIFF
--- a/packages/cbioportal-clinical-timeline/src/CustomTrack.tsx
+++ b/packages/cbioportal-clinical-timeline/src/CustomTrack.tsx
@@ -38,10 +38,6 @@ const CustomTrack: React.FunctionComponent<ICustomTrackProps> = function({
                 y={0}
                 height={specification.height(store)}
                 width={width}
-                // hide tooltip when mouse over the background rect
-                onMouseMove={() => {
-                    //store.setTooltipModel(null); // TODO!
-                }}
             />
             {specification.renderTrack(store)}
             <line

--- a/packages/cbioportal-clinical-timeline/src/CustomTrack.tsx
+++ b/packages/cbioportal-clinical-timeline/src/CustomTrack.tsx
@@ -40,7 +40,7 @@ const CustomTrack: React.FunctionComponent<ICustomTrackProps> = function({
                 width={width}
                 // hide tooltip when mouse over the background rect
                 onMouseMove={() => {
-                    store.setTooltipModel(null);
+                    //store.setTooltipModel(null); // TODO!
                 }}
             />
             {specification.renderTrack(store)}

--- a/packages/cbioportal-clinical-timeline/src/Timeline.tsx
+++ b/packages/cbioportal-clinical-timeline/src/Timeline.tsx
@@ -214,6 +214,11 @@ function bindToDOMEvents(store: TimelineStore, refs: any) {
                     preventDefault = true;
                 }
                 break;
+            case 27:
+                // escape
+                store.removeAllTooltips();
+                preventDefault = true;
+                break;
         }
         if (preventDefault) {
             e.preventDefault();

--- a/packages/cbioportal-clinical-timeline/src/Timeline.tsx
+++ b/packages/cbioportal-clinical-timeline/src/Timeline.tsx
@@ -195,23 +195,25 @@ const hoverCallback = (
 function bindToDOMEvents(store: TimelineStore, refs: any) {
     const keydown = function(e: JQuery.Event) {
         let preventDefault = false;
-        if (store.tooltipContent !== null) {
-            switch (e.which) {
-                case 37:
-                //left
-                case 40:
-                    //down
-                    store.prevTooltipEvent();
+        switch (e.which) {
+            case 37:
+            //left
+            case 40:
+                //down
+                if (store.prevTooltipEvent()) {
                     preventDefault = true;
-                    break;
-                case 38:
-                //up
-                case 39:
-                    //right
-                    store.nextTooltipEvent();
+                }
+                break;
+            case 38:
+            //up
+            case 39:
+            //right
+            case 32:
+                //spacebar
+                if (store.nextTooltipEvent()) {
                     preventDefault = true;
-                    break;
-            }
+                }
+                break;
         }
         if (preventDefault) {
             e.preventDefault();
@@ -225,8 +227,14 @@ function bindToDOMEvents(store: TimelineStore, refs: any) {
     };
     jQuery(window).on('resize', resize);
 
+    const mouseleave = function() {
+        store.removeAllTooltips();
+    };
+    jQuery('body').on('mouseleave', mouseleave);
+
     return function() {
         jQuery(window).off('resize', resize);
+        jQuery('body').off('mouseleave', mouseleave);
         jQuery(document).off('keydown', keydown);
     };
 }

--- a/packages/cbioportal-clinical-timeline/src/TimelineStore.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TimelineStore.tsx
@@ -128,6 +128,16 @@ export class TimelineStore {
         this.tooltipModelsByUid.clear();
     }
 
+    @action
+    removeAllTooltipsExcept(tooltipUid: string) {
+        const uids = this.tooltipModelsByUid.keys();
+        for (const uid of uids) {
+            if (uid !== tooltipUid) {
+                this.tooltipModelsByUid.delete(uid);
+            }
+        }
+    }
+
     @autobind
     @action
     togglePinTooltip(tooltipUid: string) {
@@ -207,6 +217,7 @@ export class TimelineStore {
             <div
                 onMouseEnter={() => this.setHoveredTooltipUid(uid)}
                 onMouseMove={() => this.setHoveredTooltipUid(uid)}
+                onClick={() => this.removeAllTooltipsExcept(uid)}
             >
                 {multipleItems && (
                     <div

--- a/packages/cbioportal-clinical-timeline/src/TimelineTrack.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TimelineTrack.tsx
@@ -276,13 +276,6 @@ export const TimelineTrack: React.FunctionComponent<
                 y={0}
                 height={height}
                 width={width}
-                /*onMouseMove={() => {
-                    // hide tooltip when mouse over the background rect
-                    if (tooltipUid !== null && !store.isTooltipPinned(tooltipUid)) {
-                        store.removeTooltip(tooltipUid);
-                        setTooltipUid(null);
-                    }
-                }}*/
             />
             {trackData.trackType === TimelineTrackType.LINE_CHART &&
                 renderLineChartLines(linePoints)}

--- a/packages/cbioportal-clinical-timeline/src/TimelineTrack.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TimelineTrack.tsx
@@ -363,32 +363,34 @@ export const EventTooltipContent: React.FunctionComponent<{
     return (
         <div>
             <table>
-                {_.map(event.event.attributes, (att: any) => {
-                    return (
-                        <tr>
-                            <th>{att.key.replace('_', ' ')}</th>
-                            <td>{att.value}</td>
-                        </tr>
-                    );
-                })}
-                <tr>
-                    <th>START DATE:</th>
-                    <td className={'nowrap'}>
-                        {formatDate(
-                            event.event.startNumberOfDaysSinceDiagnosis
-                        )}
-                    </td>
-                </tr>
-                {event.event.endNumberOfDaysSinceDiagnosis && (
+                <tbody>
+                    {_.map(event.event.attributes, (att: any) => {
+                        return (
+                            <tr>
+                                <th>{att.key.replace('_', ' ')}</th>
+                                <td>{att.value}</td>
+                            </tr>
+                        );
+                    })}
                     <tr>
-                        <th>END DATE:</th>
+                        <th>START DATE:</th>
                         <td className={'nowrap'}>
                             {formatDate(
-                                event.event.endNumberOfDaysSinceDiagnosis
+                                event.event.startNumberOfDaysSinceDiagnosis
                             )}
                         </td>
                     </tr>
-                )}
+                    {event.event.endNumberOfDaysSinceDiagnosis && (
+                        <tr>
+                            <th>END DATE:</th>
+                            <td className={'nowrap'}>
+                                {formatDate(
+                                    event.event.endNumberOfDaysSinceDiagnosis
+                                )}
+                            </td>
+                        </tr>
+                    )}
+                </tbody>
             </table>
         </div>
     );

--- a/packages/cbioportal-clinical-timeline/src/TimelineTracks.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TimelineTracks.tsx
@@ -15,6 +15,7 @@ import { Popover } from 'react-bootstrap';
 import { flattenTracks, sortNestedTracks } from './lib/helpers';
 import CustomTrack, { CustomTrackSpecification } from './CustomTrack';
 import { TICK_AXIS_HEIGHT } from './TickAxis';
+import { useObserver } from 'mobx-react-lite';
 
 export interface ITimelineTracks {
     store: TimelineStore;
@@ -64,31 +65,30 @@ export const TimelineTracks: React.FunctionComponent<
                         );
                     })}
             </g>
-            {store.tooltipContent &&
-                (() => {
-                    const placementLeft = store.mousePosition.x > width / 2;
-                    return (
-                        <Portal container={document.body}>
-                            <Popover
-                                arrowOffsetTop={17}
-                                placement={placementLeft ? 'left' : 'right'}
-                                style={{
-                                    transform: placementLeft
-                                        ? 'translate(-100%, 0)'
-                                        : '',
-                                }}
-                                className={'tl-timeline-tooltip'}
-                                positionLeft={
-                                    store.mousePosition.x +
-                                    (placementLeft ? -10 : 10)
-                                }
-                                positionTop={store.mousePosition.y - 17}
-                            >
-                                {store.tooltipContent}
-                            </Popover>
-                        </Portal>
-                    );
-                })()}
+            {store.tooltipModels.map(([uid, model]) => {
+                const position = model.position || store.mousePosition;
+                const placementLeft = position.x > width / 2;
+                return (
+                    <Portal container={document.body}>
+                        <Popover
+                            arrowOffsetTop={17}
+                            placement={placementLeft ? 'left' : 'right'}
+                            style={{
+                                transform: placementLeft
+                                    ? 'translate(-100%, 0)'
+                                    : '',
+                            }}
+                            className={'tl-timeline-tooltip'}
+                            positionLeft={
+                                position.x + (placementLeft ? -10 : 10)
+                            }
+                            positionTop={position.y - 17}
+                        >
+                            {store.getTooltipContent(uid, model)}
+                        </Popover>
+                    </Portal>
+                );
+            })}
         </>
     );
 });

--- a/packages/cbioportal-clinical-timeline/src/TimelineTracks.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TimelineTracks.tsx
@@ -78,7 +78,7 @@ export const TimelineTracks: React.FunctionComponent<
                                     ? 'translate(-100%, 0)'
                                     : '',
                             }}
-                            className={'tl-timeline-tooltip'}
+                            className={'tl-timeline-tooltip cbioTooltip'}
                             positionLeft={
                                 position.x + (placementLeft ? -10 : 10)
                             }

--- a/packages/cbioportal-clinical-timeline/src/timeline.scss
+++ b/packages/cbioportal-clinical-timeline/src/timeline.scss
@@ -113,6 +113,8 @@ $borderColor: #ccc;
 
 .tl-timeline-tooltip {
     background-color: #000000 !important;
+    max-width: 480px !important;
+    min-width: 300px;
 
     &:hover {
         z-index: 1070 !important;

--- a/packages/cbioportal-clinical-timeline/src/timeline.scss
+++ b/packages/cbioportal-clinical-timeline/src/timeline.scss
@@ -112,7 +112,7 @@ $borderColor: #ccc;
 }
 
 .tl-timeline-tooltip {
-    background-color: #000000 !important;
+    //background-color: #000000 !important;
     max-width: 480px !important;
     min-width: 300px;
 
@@ -120,20 +120,20 @@ $borderColor: #ccc;
         z-index: 1070 !important;
     }
 
-    .arrow {
-        border-right-color: #000000 !important;
-        border-left-color: #000000 !important;
-
-        &:after {
-            border-right-color: #000000 !important;
-            border-left-color: #000000 !important;
-        }
-    }
+    //.arrow {
+    //    border-right-color: #000000 !important;
+    //    border-left-color: #000000 !important;
+    //
+    //    &:after {
+    //        border-right-color: #000000 !important;
+    //        border-left-color: #000000 !important;
+    //    }
+    //}
     .popover-content {
         padding: 2px 5px !important;
         border: none;
-        background-color: #000000;
-        color: #fff;
+        //background-color: #000000;
+        //color: #fff;
         font-size: 10px;
 
         td,

--- a/packages/cbioportal-clinical-timeline/src/timeline.scss
+++ b/packages/cbioportal-clinical-timeline/src/timeline.scss
@@ -114,6 +114,10 @@ $borderColor: #ccc;
 .tl-timeline-tooltip {
     background-color: #000000 !important;
 
+    &:hover {
+        z-index: 1070 !important;
+    }
+
     .arrow {
         border-right-color: #000000 !important;
         border-left-color: #000000 !important;

--- a/src/globalStyles/global.scss
+++ b/src/globalStyles/global.scss
@@ -121,6 +121,9 @@ th.reactable-header-sort-asc:after {
 
 .rc-tooltip {
     opacity: 1 !important;
+    border-radius: $border-radius-base;
+    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.2);
+    padding: 0;
 
     &.hideTooltipArrow {
         .rc-tooltip-arrow {
@@ -518,6 +521,8 @@ h3.hr {
         position: absolute !important;
         display: block !important;
         max-width: 600px !important;
+        border-radius: $border-radius-base;
+        box-shadow: 0 2px 3px rgba(0, 0, 0, 0.2);
         div:last-child {
             white-space: nowrap;
         }

--- a/src/pages/patientView/timeline2/TimelineWrapper.tsx
+++ b/src/pages/patientView/timeline2/TimelineWrapper.tsx
@@ -227,35 +227,43 @@ const TimelineWrapper: React.FunctionComponent<ITimeline2Props> = observer(
                                 if (sampleWithClinicalData) {
                                     return (
                                         <table>
-                                            <tr>
-                                                <th>SAMPLE ID</th>
-                                                <td>
-                                                    {sampleWithClinicalData.id}
-                                                </td>
-                                            </tr>
-                                            {sampleWithClinicalData.clinicalData.map(
-                                                d => {
-                                                    return (
-                                                        <tr>
-                                                            <th>
-                                                                {d.clinicalAttributeId
-                                                                    .toUpperCase()
-                                                                    .replace(
-                                                                        /_/g,
-                                                                        ' '
-                                                                    )}
-                                                            </th>
-                                                            <td>{d.value}</td>
-                                                        </tr>
-                                                    );
-                                                }
-                                            )}
-                                            <tr>
-                                                <th>START DATE</th>
-                                                <td className={'nowrap'}>
-                                                    {formatDate(event.start)}
-                                                </td>
-                                            </tr>
+                                            <tbody>
+                                                <tr>
+                                                    <th>SAMPLE ID</th>
+                                                    <td>
+                                                        {
+                                                            sampleWithClinicalData.id
+                                                        }
+                                                    </td>
+                                                </tr>
+                                                {sampleWithClinicalData.clinicalData.map(
+                                                    d => {
+                                                        return (
+                                                            <tr>
+                                                                <th>
+                                                                    {d.clinicalAttributeId
+                                                                        .toUpperCase()
+                                                                        .replace(
+                                                                            /_/g,
+                                                                            ' '
+                                                                        )}
+                                                                </th>
+                                                                <td>
+                                                                    {d.value}
+                                                                </td>
+                                                            </tr>
+                                                        );
+                                                    }
+                                                )}
+                                                <tr>
+                                                    <th>START DATE</th>
+                                                    <td className={'nowrap'}>
+                                                        {formatDate(
+                                                            event.start
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                            </tbody>
                                         </table>
                                     );
                                 } else {


### PR DESCRIPTION
(1) Support keeping tootips open using clicking, and opening multiple tooltips
(2) Mouse out of page hides all tooltips
(3) Hovering a tooltip brings it to front, and allow you to cycle through multiple events on it
(4) Better tooltip size with min-width and max-width
(5) Escape key clears all tooltips
(6) Clicking on a tooltip removes all others