### PR TITLE
Small improvements to e2e scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ In a terminal, start the frontend dev server
 ```
 export BRANCH_ENV=custom
 yarn install --frozen-lockfile // only necessary first time
-yarn buildDLL:dev // only necessary first tiem
+yarn buildDLL:dev // only necessary first time
 yarn start
 ```
 
@@ -208,7 +208,7 @@ yarn start
 cd end-to-end-test
 yarn
 ```
-5. In a second terminal at project root, spinup the backend (api) instance:
+4. In a second terminal at project root, spinup the backend (api) instance:
 
 ```
 // if you are running for first time, you will need to build the docker containers.
@@ -219,7 +219,12 @@ yarn
 yarn run e2e:spinup
 ```
 
-6. When backend instance is operational, you can run tests. Upon executing
+After the script has completed, you can verify that the instance is operational by
+visiting [http://localhost:8080](http://localhost:8080) in your browser. Once you
+log into keycloak (`testuser`/`P@ssword1`), you should see the cBioPortal home page
+with several studies loaded.
+
+5. When backend instance is operational, you can run tests. Upon executing
 the command below, a browser should open and you should see your tests execute.
 
 ```
@@ -231,6 +236,10 @@ yarn run e2e:local --grep=some.spec*
 
 ```
 
+When you want to shut down your local cBioPortal instance, you can do so by running:
+```
+yarn run e2e:spindown
+```
 
 
 ### Running e2e-localdb tests _CircleCI_ or _CircleCI+PR_ context

--- a/end-to-end-test/local/docker_compose/initdb.sh
+++ b/end-to-end-test/local/docker_compose/initdb.sh
@@ -23,6 +23,7 @@ fi
 
 sudo rm -rf $CBIO_DB_DATA_DIR/*
 mkdir -p $CBIO_DB_DATA_DIR
+docker volume rm cbioportal-docker-compose_cbioportal_mysql_data
 docker-compose $compose_extensions up -d cbioportal
 echo
 

--- a/end-to-end-test/local/docker_compose/stop.sh
+++ b/end-to-end-test/local/docker_compose/stop.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+set -u # unset variables throw error
+set -o pipefail # pipes fail when partial command fails
+shopt -s nullglob # allows files and dir globs to be null - needed in 'for ... do' loops that should not run when no files/dirs are detected by expansion
+
+DIR=$PWD
+
+cd $E2E_WORKSPACE/cbioportal-docker-compose
+
+compose_extensions="-f docker-compose.yml -f $TEST_HOME/docker_compose/cbioportal.yml -f $TEST_HOME/docker_compose/keycloak.yml"
+if [ $CUSTOM_BACKEND -eq 1 ]; then
+  compose_extensions="$compose_extensions -f $TEST_HOME/docker_compose/cbioportal-custombranch.yml"
+fi
+
+if (ls "$KC_DB_DATA_DIR"/* 2> /dev/null > /dev/null); then
+  compose_extensions="$compose_extensions -f $TEST_HOME/docker_compose/keycloak_init.yml"
+fi
+
+docker-compose $compose_extensions down
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "prettierAll": "yarn run prettier --write $(git ls-files | grep '\\(.js\\|.ts\\|.scss\\|.css\\)')",
     "checkIncorrectImportStatements": "./scripts/check_incorrect_import_statements.sh",
     "syncmock": "node src/test/fetchMockData.js --diff",
-    "e2e:spinup": "sh ./scripts/e2e.sh",
+    "e2e:spinup": "bash ./scripts/e2e.sh",
+    "e2e:spindown": "bash ./scripts/e2e-stop.sh",
     "e2e:local": "export CBIOPORTAL_URL=http://localhost:8080 && export && export SCREENSHOT_DIRECTORY=/local/screenshots/ && cd end-to-end-test && yarn run test-webdriver-manager-local",
     "e2e:remote": "export CBIOPORTAL_URL=https://www.cbioportal.org && export SCREENSHOT_DIRECTORY=/remote/screenshots/ && cd end-to-end-test && yarn run test-webdriver-manager-remote",
     "e2e:report": "npx http-server end-to-end-test -o /shared/imageCompare.html -p 8089"

--- a/scripts/e2e-stop.sh
+++ b/scripts/e2e-stop.sh
@@ -1,0 +1,22 @@
+MY_PATH="`dirname \"$0\"`"              # relative
+MY_PATH="`( cd \"$MY_PATH\" && pwd )`"  # absolutized and normalized
+if [ -z "$MY_PATH" ] ; then
+  # error; for some reason, the path is not accessible
+  # to the script (e.g. permissions re-evaled after suid)
+  exit 1  # fail
+fi
+
+
+export PORTAL_SOURCE_DIR=$PWD;
+export TEST_HOME=$PORTAL_SOURCE_DIR/end-to-end-test/local
+export E2E_WORKSPACE=$PORTAL_SOURCE_DIR/e2e-localdb-workspace
+export BACKEND=cbioportal:master
+
+cd $PORTAL_SOURCE_DIR
+
+echo "$TEST_HOME"
+
+cat <<< $($TEST_HOME/runtime-config/setup_environment.sh)
+$($TEST_HOME/runtime-config/setup_environment.sh)
+
+$TEST_HOME/docker_compose/stop.sh


### PR DESCRIPTION
- change `sh` to `bash`, as not all shells are compatible with the
`<<<` in the e2e scripts
- added `e2e:spindown` command. It just runs `docker-compose down`
- added some documentation on how to verify that the server is running
