### PR TITLE
ci: add Playwright e2e GitHub Action

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       PW_DOCKER: '1'
       CI: 'true'
@@ -78,9 +78,9 @@ jobs:
         shell: bash
         run: |
           if [ -n "${{ inputs.grep }}" ]; then
-            npx playwright test --shard=${{ matrix.shard }}/4 --grep "${{ inputs.grep }}"
+            npx playwright test --shard=${{ matrix.shard }}/8 --grep "${{ inputs.grep }}"
           else
-            npx playwright test --shard=${{ matrix.shard }}/4
+            npx playwright test --shard=${{ matrix.shard }}/8
           fi
 
       - name: Upload report + traces

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -6,7 +6,7 @@ on:
       - 'src/**'
       - 'packages/**'
       - 'end-to-end-test-playwright/**'
-      - '.github/workflows/playwright-e2e/**'
+      - '.github/workflows/playwright-e2e.yml'
   push:
     branches:
       - master
@@ -15,7 +15,7 @@ on:
       - 'src/**'
       - 'packages/**'
       - 'end-to-end-test-playwright/**'
-      - '.github/workflows/playwright-e2e/**'
+      - '.github/workflows/playwright-e2e.yml'
   workflow_dispatch:
     inputs:
       cbioportal_url:

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,0 +1,93 @@
+name: Playwright E2E
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'packages/**'
+      - 'end-to-end-test-playwright/**'
+      - '.github/workflows/playwright-e2e/**'
+  push:
+    branches:
+      - master
+      - rc
+    paths:
+      - 'src/**'
+      - 'packages/**'
+      - 'end-to-end-test-playwright/**'
+      - '.github/workflows/playwright-e2e/**'
+  workflow_dispatch:
+    inputs:
+      cbioportal_url:
+        description: 'cBioPortal URL to test against'
+        type: string
+        required: false
+        default: 'https://www.cbioportal.org'
+      grep:
+        description: 'Playwright --grep filter (optional)'
+        type: string
+        required: false
+
+concurrency:
+  group: playwright-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  image-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.resolve.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: resolve
+        working-directory: end-to-end-test-playwright
+        run: |
+          VERSION=$(node -p "require('./package.json').devDependencies['@playwright/test'].replace(/^[\^~]/, '')")
+          echo "image=mcr.microsoft.com/playwright:v${VERSION}-jammy" >> "$GITHUB_OUTPUT"
+
+  e2e:
+    needs: image-tag
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.image-tag.outputs.image }}
+      options: --ipc=host
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    env:
+      PW_DOCKER: '1'
+      CI: 'true'
+      HOME: /tmp
+      CBIOPORTAL_URL: ${{ inputs.cbioportal_url || 'https://www.cbioportal.org' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: end-to-end-test-playwright/package-lock.json
+
+      - name: Install dependencies
+        working-directory: end-to-end-test-playwright
+        run: npm ci
+
+      - name: Run Playwright tests (shard ${{ matrix.shard }}/4)
+        working-directory: end-to-end-test-playwright
+        run: |
+          ARGS=(--shard=${{ matrix.shard }}/4)
+          if [ -n "${{ inputs.grep }}" ]; then
+            ARGS+=(--grep "${{ inputs.grep }}")
+          fi
+          npx playwright test "${ARGS[@]}"
+
+      - name: Upload report + traces
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-shard-${{ matrix.shard }}
+          path: |
+            end-to-end-test-playwright/playwright-report
+            end-to-end-test-playwright/test-results
+          retention-days: 14

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     env:
       PW_DOCKER: '1'
       CI: 'true'
@@ -78,9 +78,9 @@ jobs:
         shell: bash
         run: |
           if [ -n "${{ inputs.grep }}" ]; then
-            npx playwright test --shard=${{ matrix.shard }}/8 --grep "${{ inputs.grep }}"
+            npx playwright test --shard=${{ matrix.shard }}/12 --grep "${{ inputs.grep }}"
           else
-            npx playwright test --shard=${{ matrix.shard }}/8
+            npx playwright test --shard=${{ matrix.shard }}/12
           fi
 
       - name: Upload report + traces

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   image-tag:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.resolve.outputs.image }}
     steps:
@@ -47,7 +47,7 @@ jobs:
 
   e2e:
     needs: image-tag
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     container:
       image: ${{ needs.image-tag.outputs.image }}
       options: --ipc=host

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -75,12 +75,13 @@ jobs:
 
       - name: Run Playwright tests (shard ${{ matrix.shard }}/4)
         working-directory: end-to-end-test-playwright
+        shell: bash
         run: |
-          ARGS=(--shard=${{ matrix.shard }}/4)
           if [ -n "${{ inputs.grep }}" ]; then
-            ARGS+=(--grep "${{ inputs.grep }}")
+            npx playwright test --shard=${{ matrix.shard }}/4 --grep "${{ inputs.grep }}"
+          else
+            npx playwright test --shard=${{ matrix.shard }}/4
           fi
-          npx playwright test "${ARGS[@]}"
 
       - name: Upload report + traces
         if: always()

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   image-tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     outputs:
       image: ${{ steps.resolve.outputs.image }}
     steps:
@@ -47,7 +47,7 @@ jobs:
 
   e2e:
     needs: image-tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     container:
       image: ${{ needs.image-tag.outputs.image }}
       options: --ipc=host


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/playwright-e2e.yml` to run the Playwright suite in CI
- Runs inside the pinned `mcr.microsoft.com/playwright:v1.59.1-jammy` image (version resolved from `end-to-end-test-playwright/package.json` by a setup job)
- Sharded 4x with `fail-fast: false`; uploads HTML report + traces per shard on any outcome
- Triggers: `pull_request` and `push` (master/rc) on frontend paths, plus manual `workflow_dispatch` with `cbioportal_url` and `grep` inputs

## Test plan
- [ ] Opening this PR triggers the "Playwright E2E" workflow
- [ ] `image-tag` job resolves to `v1.59.1-jammy`
- [ ] All 4 shards run in parallel against https://www.cbioportal.org
- [ ] Artifacts (`playwright-report-shard-N`) upload on both success and failure paths