### PR TITLE
Add mRNA expression boxplot tab to patient view

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,8 +354,15 @@ jobs:
       CI: 'true'
       HOME: /tmp
       LOCALDEV: '1'
-      CBIOPORTAL_URL: https://www.cbioportal.org
-      BRANCH_ENV: master
+      # CBIOPORTAL_URL and BRANCH_ENV are intentionally NOT hardcoded here.
+      # scripts/with-env.sh dispatches through scripts/env_vars.sh, which
+      # picks env/${BRANCH}.sh based on the PR's target branch (queried via
+      # the GitHub API). That way rc-targeted PRs hit rc.cbioportal.org,
+      # release-targeted PRs hit the appropriate release backend, etc.
+      # Override for a one-off manual trigger by setting the
+      # manual_trigger_branch_env pipeline parameter — forwarded below
+      # and read by env_vars.sh's MANUAL_TRIGGER_BRANCH_ENV branch.
+      MANUAL_TRIGGER_BRANCH_ENV: << pipeline.parameters.manual_trigger_branch_env >>
       FRONTEND_TEST_USE_LOCAL_DIST: 'true'
       PLAYWRIGHT_JUNIT_OUTPUT_NAME: test-results/junit.xml
       # Optional grep filter for targeted smoke runs. Empty by default →
@@ -390,6 +397,17 @@ jobs:
           # --frozen-lockfile: fail if pnpm-lock.yaml would change,
           # the pnpm equivalent of `npm ci`.
           command: pnpm install --frozen-lockfile --ignore-workspace
+      - run:
+          # Dedicated step so the resolved backend appears in the CircleCI
+          # step list at-a-glance, without having to expand "Run Playwright
+          # shard". The actual env resolution still happens inside
+          # with-env.sh at playwright-test invocation time — this step is
+          # purely a visibility pre-flight, runs the same wrapper with a
+          # noop command, so what it prints is exactly what the test step
+          # will use.
+          name: Resolved backend URL
+          working_directory: /tmp/repo/cbioportal-frontend/end-to-end-test-playwright
+          command: ./scripts/with-env.sh true
       - run:
           name: Start frontend dev server (pnpm serveDist) on localhost:3000
           background: true
@@ -436,7 +454,10 @@ jobs:
             # (CPU-bound contention with serveDist + runner sharing the
             # 4th core). Only describes opted into mode: 'parallel'
             # actually use the extra workers; the rest still serialize.
-            pnpm exec playwright test --workers=3 \
+            #
+            # with-env.sh resolves CBIOPORTAL_URL via scripts/env_vars.sh
+            # (PR-target-branch aware) before exec'ing playwright.
+            ./scripts/with-env.sh pnpm exec playwright test --workers=3 \
               --shard="${SHARD_NUM}/${CIRCLE_NODE_TOTAL}" \
               --reporter=list,junit,blob \
               $GREP_ARG

--- a/end-to-end-test-playwright/README.md
+++ b/end-to-end-test-playwright/README.md
@@ -86,6 +86,27 @@ localdb tests without waiting for a Docker pull.
 script name is forwarded to `playwright test`, so flags like
 `--debug`, `--headed`, `--grep`, `--trace on` all work.
 
+## Pointing at a different backend (CBIOPORTAL_URL)
+
+All test entry points route through `scripts/with-env.sh`, which resolves
+`CBIOPORTAL_URL` in this order — first match wins:
+
+1. **`CBIOPORTAL_URL` already set in your shell** — used as-is. The simple
+   one-off override:
+   ```bash
+   CBIOPORTAL_URL=https://rc.cbioportal.org pnpm test
+   ```
+2. **`BRANCH_ENV` set (local) or `CIRCLECI`/`NETLIFY` set (CI)** — delegate
+   to `../scripts/env_vars.sh`, which picks `../env/${BRANCH}.sh` based on
+   `$BRANCH_ENV` locally, or the PR's target branch in CI. `../env/custom.sh`
+   layers on top for personal overrides.
+3. **Nothing set** — `playwright.config.ts`'s hardcoded default
+   (`https://www.cbioportal.org`) kicks in.
+
+In CI, this means a PR targeting `rc` automatically runs against
+`rc.cbioportal.org`; a PR targeting `master` runs against
+`www.cbioportal.org`; etc. — matching the legacy WebdriverIO behavior.
+
 ## Updating references when a real visual change lands
 
 1. Land the code change.

--- a/end-to-end-test-playwright/package.json
+++ b/end-to-end-test-playwright/package.json
@@ -7,9 +7,9 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "playwright test --headed",
-    "test:update": "playwright test --update-snapshots",
-    "test:ui": "playwright test --headed --ui",
+    "test": "./scripts/with-env.sh playwright test --headed",
+    "test:update": "./scripts/with-env.sh playwright test --update-snapshots",
+    "test:ui": "./scripts/with-env.sh playwright test --headed --ui",
     "test:docker": "./scripts/docker-test.sh",
     "test:docker:update": "./scripts/docker-test.sh --update-snapshots",
     "test:docker:localdb": "PW_LOCAL=1 CBIOPORTAL_URL=http://localhost:8080 ./scripts/docker-test.sh tests/local",

--- a/end-to-end-test-playwright/scripts/docker-test.sh
+++ b/end-to-end-test-playwright/scripts/docker-test.sh
@@ -25,6 +25,16 @@ if ! command -v docker >/dev/null 2>&1; then
     exit 1
 fi
 
+# Resolve CBIOPORTAL_URL on the HOST before launching the container.
+# The same with-env.sh wrapper is used everywhere — pass `true` as the
+# command so it exits cleanly after resolution. We re-export resulting
+# vars so the `docker run -e` lines below pick them up.
+if [[ -z "${CBIOPORTAL_URL:-}" ]]; then
+    if [[ -n "${CIRCLECI:-}" || -n "${NETLIFY:-}" || -n "${BRANCH_ENV:-}" ]]; then
+        eval "$(bash ../scripts/env_vars.sh)"
+    fi
+fi
+
 # Pin the image to the @playwright/test version declared in package.json.
 # Any drift between the image and the library produces flaky comparisons,
 # so this MUST stay in lockstep. The custom CI image is tagged with the
@@ -33,7 +43,7 @@ PLAYWRIGHT_VERSION=$(node -p "require('./package.json').devDependencies['@playwr
 IMAGE="ghcr.io/cbioportal/cbioportal-frontend-playwright-ci:v${PLAYWRIGHT_VERSION}-jammy"
 
 echo "Playwright Docker image: ${IMAGE}"
-echo "Target: ${CBIOPORTAL_URL:-https://www.cbioportal.org}"
+echo "Target: ${CBIOPORTAL_URL:-https://www.cbioportal.org (playwright.config.ts default)}"
 
 # --ipc=host       avoids Chromium crashes from the default 64 MB shm
 # --user           writes files as the host user so snapshots aren't root-owned
@@ -69,7 +79,7 @@ exec docker run --rm -i \
     -e PW_DOCKER=1 \
     -e PW_REMAP_LOCALHOST=1 \
     -e HOME=/tmp \
-    -e CBIOPORTAL_URL="${CBIOPORTAL_URL:-https://www.cbioportal.org}" \
+    -e CBIOPORTAL_URL="${CBIOPORTAL_URL:-}" \
     -e CI="${CI:-}" \
     -e LOCALDEV="${LOCALDEV}" \
     -e PW_LOCAL="${PW_LOCAL:-}" \

--- a/end-to-end-test-playwright/scripts/with-env.sh
+++ b/end-to-end-test-playwright/scripts/with-env.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Resolve CBIOPORTAL_URL (and friends) before running a command.
+#
+# Resolution order — first match wins:
+#   1. CBIOPORTAL_URL already set in the environment → use as-is.
+#      This is the simple per-run override path:
+#          CBIOPORTAL_URL=https://rc.cbioportal.org pnpm test
+#   2. CIRCLECI / NETLIFY / BRANCH_ENV set → delegate to
+#      scripts/env_vars.sh, which picks env/${BRANCH}.sh based on:
+#        - CI: PR's target branch (via GitHub API), MANUAL_TRIGGER_BRANCH_ENV,
+#          or branch name
+#        - Local: $BRANCH_ENV, plus env/custom.sh overrides
+#   3. Nothing set → fall through. playwright.config.ts's hardcoded default
+#      (https://www.cbioportal.org) kicks in.
+#
+# Why this exists: the old WebdriverIO e2e suite ran
+#   eval "$(../scripts/env_vars.sh)" && pnpm run test-webdriver-manager-remote
+# so the URL tracked the PR's target branch. The Playwright suite lost that
+# wiring during migration. This wrapper restores it while keeping the
+# "just set CBIOPORTAL_URL" path simple for one-off runs.
+set -euo pipefail
+
+if [[ -z "${CBIOPORTAL_URL:-}" ]]; then
+    if [[ -n "${CIRCLECI:-}" || -n "${NETLIFY:-}" || -n "${BRANCH_ENV:-}" ]]; then
+        SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+        eval "$(bash "$SCRIPT_DIR/../../scripts/env_vars.sh")"
+    fi
+fi
+
+# Surface the resolved backend loudly so anyone reading test output (CI
+# log, local terminal, docker run) can see at a glance what the suite
+# is actually pointed at. Without this it's surprisingly easy to spend
+# 20 minutes debugging a "test failure" that's really an instance mismatch.
+echo "============================================================"
+echo "  CBIOPORTAL_URL: ${CBIOPORTAL_URL:-(unset — playwright.config.ts default kicks in)}"
+echo "  BRANCH_ENV:     ${BRANCH_ENV:-(unset)}"
+echo "============================================================"
+
+exec "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,16 @@
                     </execution>
 
                     <execution>
+                        <id>enable pnpm shim</id>
+                        <goals>
+                            <goal>corepack</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>enable --install-directory ./node pnpm</arguments>
+                        </configuration>
+                    </execution>
+
+                    <execution>
                         <id>pnpm install</id>
                         <goals>
                             <goal>corepack</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -40,19 +40,19 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.10.0</version>
+                <version>2.0.0</version>
 
                 <executions>
                     <execution>
                         <!-- optional: you don't really need execution ids, but it looks nice in your build log. -->
-                        <id>install node and yarn</id>
+                        <id>install node and corepack</id>
                         <goals>
-                            <goal>install-node-and-yarn</goal>
+                            <goal>install-node-and-corepack</goal>
                         </goals>
 
                         <configuration>
                             <nodeVersion>v22.18.0</nodeVersion>
-                            <yarnVersion>v1.22.22</yarnVersion>
+                            <corepackVersion>0.25.2</corepackVersion>
                         </configuration>
 
                         <!-- optional: default phase is "generate-resources" -->
@@ -60,23 +60,23 @@
                     </execution>
 
                     <execution>
-                        <id>yarn install</id>
+                        <id>pnpm install</id>
                         <goals>
-                            <goal>yarn</goal>
+                            <goal>corepack</goal>
                         </goals>
                         <configuration>
-                            <arguments>--production=true --frozen-lockfile</arguments>
+                            <arguments>pnpm install --frozen-lockfile</arguments>
                         </configuration>
 
                     </execution>
 
                     <execution>
-                        <id>yarn run buildAll</id>
+                        <id>pnpm run buildAll</id>
                         <goals>
-                            <goal>yarn</goal>
+                            <goal>corepack</goal>
                         </goals>
                         <configuration>
-                            <arguments>run buildAll</arguments>
+                            <arguments>pnpm run buildAll</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/pages/patientView/PatientViewPageTabs.tsx
+++ b/src/pages/patientView/PatientViewPageTabs.tsx
@@ -21,6 +21,7 @@ import { getDigitalSlideArchiveIFrameUrl } from 'shared/api/urls';
 import TrialMatchTable from 'pages/patientView/trialMatch/TrialMatchTable';
 import _ from 'lodash';
 import MutationalSignaturesContainer from 'pages/patientView/mutationalSignatures/MutationalSignaturesContainer';
+import MrnaTabContent from 'pages/patientView/mrna/MrnaTabContent';
 import { buildCustomTabs } from 'shared/lib/customTabs/customTabHelpers';
 import * as React from 'react';
 import SampleManager from 'pages/patientView/SampleManager';
@@ -49,6 +50,7 @@ export enum PatientViewPageTabs {
     TrialMatchTab = 'trialMatchTab',
     MutationalSignatures = 'mutationalSignatures',
     PathwayMapper = 'pathways',
+    MRNA = 'mrna',
 }
 
 export const PatientViewResourceTabPrefix = 'openResource_';
@@ -704,6 +706,12 @@ export function tabs(
                 />
             </MSKTab>
         );
+
+    tabs.push(
+        <MSKTab key={9} id={PatientViewPageTabs.MRNA} linkText="MRNA">
+            <MrnaTabContent store={pageComponent.patientViewPageStore} />
+        </MSKTab>
+    );
 
     pageComponent.resourceTabs.component &&
         /* @ts-ignore */

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -1479,14 +1479,36 @@ export class PatientViewPageStore {
             ),
     });
 
-    // Resolve the mRNA tab gene symbols to Gene objects (for entrez ids).
-    readonly mrnaTabGenes = remoteData<Gene[]>(
+    // Genes selected in the mRNA tab gene chooser (drives the chart).
+    @observable.ref mrnaTabGeneSymbols: string[] = MRNA_TAB_GENES;
+
+    @action.bound
+    setMrnaTabGeneSymbols(symbols: string[]) {
+        this.mrnaTabGeneSymbols = symbols;
+    }
+
+    // Full gene list for the mRNA tab gene chooser options.
+    readonly mrnaTabAllGenes = remoteData<Gene[]>(
         {
             invoke: () =>
-                getClient().fetchGenesUsingPOST({
+                getClient().getAllGenesUsingGET({ projection: 'SUMMARY' }),
+        },
+        []
+    );
+
+    // Resolve the selected gene symbols to Gene objects (for entrez ids).
+    readonly mrnaTabGenes = remoteData<Gene[]>(
+        {
+            invoke: () => {
+                const symbols = this.mrnaTabGeneSymbols;
+                if (symbols.length === 0) {
+                    return Promise.resolve([]);
+                }
+                return getClient().fetchGenesUsingPOST({
                     geneIdType: 'HUGO_GENE_SYMBOL',
-                    geneIds: MRNA_TAB_GENES.map(g => g.toUpperCase()),
-                }),
+                    geneIds: symbols.map(g => g.toUpperCase()),
+                });
+            },
         },
         []
     );

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -6,8 +6,10 @@ import {
     CopyNumberCount,
     DiscreteCopyNumberData,
     DiscreteCopyNumberFilter,
+    Gene,
     GenePanel,
     GenePanelData,
+    MolecularDataFilter,
     MolecularProfile,
     Mutation,
     MutationFilter,
@@ -319,6 +321,8 @@ function transformClinicalInformationToStoreShape(
 
     return rv;
 }
+
+export const MRNA_TAB_GENES = ['TP53', 'EGFR', 'KRAS'];
 
 export class PatientViewPageStore {
     constructor(
@@ -1449,6 +1453,75 @@ export class PatientViewPageStore {
                 ),
         },
         null
+    );
+
+    // All samples in the study the current patient belongs to (mRNA tab).
+    readonly allSamplesInStudy = remoteData<Sample[]>(
+        {
+            invoke: () =>
+                getClient().getAllSamplesInStudyUsingGET({
+                    studyId: this.studyId,
+                }),
+        },
+        []
+    );
+
+    // First mRNA expression molecular profile in the study (mRNA tab).
+    readonly mrnaExpressionMolecularProfile = remoteData<
+        MolecularProfile | undefined
+    >({
+        await: () => [this.molecularProfilesInStudy],
+        invoke: async () =>
+            this.molecularProfilesInStudy.result!.find(
+                p =>
+                    p.molecularAlterationType ===
+                    AlterationTypeConstants.MRNA_EXPRESSION
+            ),
+    });
+
+    // Resolve the mRNA tab gene symbols to Gene objects (for entrez ids).
+    readonly mrnaTabGenes = remoteData<Gene[]>(
+        {
+            invoke: () =>
+                getClient().fetchGenesUsingPOST({
+                    geneIdType: 'HUGO_GENE_SYMBOL',
+                    geneIds: MRNA_TAB_GENES.map(g => g.toUpperCase()),
+                }),
+        },
+        []
+    );
+
+    // mRNA expression data for MRNA_TAB_GENES across all samples in the study.
+    readonly mrnaExpressionDataForGenes = remoteData<
+        NumericGeneMolecularData[]
+    >(
+        {
+            await: () => [
+                this.mrnaExpressionMolecularProfile,
+                this.allSamplesInStudy,
+                this.mrnaTabGenes,
+            ],
+            invoke: async () => {
+                const profile = this.mrnaExpressionMolecularProfile.result;
+                if (!profile) {
+                    return [];
+                }
+                return getClient().fetchAllMolecularDataInMolecularProfileUsingPOST(
+                    {
+                        molecularProfileId: profile.molecularProfileId,
+                        molecularDataFilter: {
+                            entrezGeneIds: this.mrnaTabGenes.result!.map(
+                                g => g.entrezGeneId
+                            ),
+                            sampleIds: this.allSamplesInStudy.result!.map(
+                                s => s.sampleId
+                            ),
+                        } as MolecularDataFilter,
+                    }
+                );
+            },
+        },
+        []
     );
 
     readonly discreteCNAData = remoteData<DiscreteCopyNumberData[]>(

--- a/src/pages/patientView/mrna/MrnaTabContent.tsx
+++ b/src/pages/patientView/mrna/MrnaTabContent.tsx
@@ -1,32 +1,50 @@
 import * as React from 'react';
 import _ from 'lodash';
 import { observer } from 'mobx-react';
-import { computed, IReactionDisposer, makeObservable, reaction } from 'mobx';
+import {
+    action,
+    computed,
+    IReactionDisposer,
+    makeObservable,
+    observable,
+    reaction,
+} from 'mobx';
 import {
     VictoryAxis,
-    VictoryBoxPlot,
     VictoryChart,
-    VictoryLabel,
+    VictoryLine,
+    VictoryScatter,
 } from 'victory';
+import ReactSelect from 'react-select';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
-import {
-    MRNA_TAB_GENES,
-    PatientViewPageStore,
-} from 'pages/patientView/clinicalInformation/PatientViewPageStore';
+import { PatientViewPageStore } from 'pages/patientView/clinicalInformation/PatientViewPageStore';
+
+interface IGeneOption {
+    label: string;
+    value: string;
+}
 
 interface IMrnaTabContentProps {
     store: PatientViewPageStore;
 }
 
 interface IBoxDatum {
-    x: string;
+    x: number;
     min: number;
     q1: number;
     median: number;
     q3: number;
     max: number;
-    n: number;
 }
+
+interface IPoint {
+    x: number;
+    y: number;
+}
+
+const RED = '#e8493a';
+const BOX_BAND = 0.34; // half-height of the jitter band around a gene row
+const MAX_GENE_OPTIONS = 50; // cap rendered options so react-select stays fast
 
 // Linear-interpolation quantile over an already-sorted ascending array.
 function quantileSorted(sorted: number[], q: number): number {
@@ -40,6 +58,15 @@ function quantileSorted(sorted: number[], q: number): number {
     return next !== undefined
         ? sorted[base] + rest * (next - sorted[base])
         : sorted[base];
+}
+
+// Deterministic [0,1) hash so jitter is stable across renders.
+function hash01(s: string): number {
+    let h = 0;
+    for (let i = 0; i < s.length; i++) {
+        h = (Math.imul(h, 31) + s.charCodeAt(i)) | 0;
+    }
+    return ((h >>> 0) % 10000) / 10000;
 }
 
 @observer
@@ -71,82 +98,411 @@ export default class MrnaTabContent extends React.Component<
         this.logDisposer?.();
     }
 
-    @computed get boxData(): IBoxDatum[] {
+    // Gene symbols that actually have data, in selected order, with row index.
+    @computed get genes(): { symbol: string; entrezGeneId: number }[] {
         const { store } = this.props;
-        const dataByEntrez = _.groupBy(
-            store.mrnaExpressionDataForGenes.result,
+        const present = new Set(
+            store.mrnaExpressionDataForGenes.result.map(d => d.entrezGeneId)
+        );
+        return store.mrnaTabGeneSymbols
+            .map(symbol => {
+                const gene = store.mrnaTabGenes.result.find(
+                    g => g.hugoGeneSymbol.toUpperCase() === symbol.toUpperCase()
+                );
+                return gene && present.has(gene.entrezGeneId)
+                    ? { symbol, entrezGeneId: gene.entrezGeneId }
+                    : null;
+            })
+            .filter((g): g is { symbol: string; entrezGeneId: number } => !!g);
+    }
+
+    @observable geneQuery: string = '';
+
+    @action.bound
+    setGeneQuery(q: string) {
+        this.geneQuery = q;
+    }
+
+    @computed get geneOptions(): IGeneOption[] {
+        return this.props.store.mrnaTabAllGenes.result.map(g => ({
+            label: g.hugoGeneSymbol,
+            value: g.hugoGeneSymbol,
+        }));
+    }
+
+    // Only the matches for the current query, capped, so react-select never
+    // renders the full ~20k gene list (which freezes the UI).
+    @computed get filteredGeneOptions(): IGeneOption[] {
+        const q = this.geneQuery.trim().toLowerCase();
+        if (!q) {
+            return [];
+        }
+        const out: IGeneOption[] = [];
+        for (const o of this.geneOptions) {
+            if (o.label.toLowerCase().includes(q)) {
+                out.push(o);
+                if (out.length >= MAX_GENE_OPTIONS) {
+                    break;
+                }
+            }
+        }
+        return out;
+    }
+
+    @computed get selectedGeneOptions(): IGeneOption[] {
+        return this.props.store.mrnaTabGeneSymbols.map(s => ({
+            label: s,
+            value: s,
+        }));
+    }
+
+    @computed get patientSampleIds(): Set<string> {
+        return new Set(this.props.store.sampleIds);
+    }
+
+    @computed get allValues(): number[] {
+        return this.props.store.mrnaExpressionDataForGenes.result
+            .map(d => d.value)
+            .filter(v => !isNaN(v));
+    }
+
+    // Use a log scale for non-negative data (e.g. TPM/RSEM) with enough spread.
+    // Zeros are allowed and rendered at a small positive floor; negatives
+    // (z-scores) force a linear scale.
+    @computed get useLog(): boolean {
+        const vals = this.allValues;
+        const positives = vals.filter(v => v > 0);
+        return (
+            vals.length > 0 &&
+            vals.every(v => v >= 0) &&
+            positives.length >= 2 &&
+            _.max(positives)! / _.min(positives)! > 10
+        );
+    }
+
+    // Smallest positive value; the lower bound for the log scale so zeros and
+    // tiny values have somewhere to render.
+    @computed get logFloor(): number {
+        return _.min(this.allValues.filter(v => v > 0)) ?? 1;
+    }
+
+    // Clamp a value into the plottable range (log can't render <= 0).
+    private clamp(v: number): number {
+        return this.useLog ? Math.max(v, this.logFloor) : v;
+    }
+
+    @computed get boxData(): IBoxDatum[] {
+        const byEntrez = _.groupBy(
+            this.props.store.mrnaExpressionDataForGenes.result,
             d => d.entrezGeneId
         );
-        // One box per gene, preserving MRNA_TAB_GENES order.
-        return MRNA_TAB_GENES.map(symbol => {
-            const gene = store.mrnaTabGenes.result.find(
-                g => g.hugoGeneSymbol.toUpperCase() === symbol.toUpperCase()
+        return this.genes.map((gene, rowIndex) => {
+            const sorted = _.sortBy(
+                (byEntrez[gene.entrezGeneId] || [])
+                    .map(d => d.value)
+                    .filter(v => !isNaN(v))
             );
-            const values = gene
-                ? (dataByEntrez[gene.entrezGeneId] || [])
-                      .map(d => d.value)
-                      .filter(v => v !== null && !isNaN(v))
-                : [];
-            const sorted = _.sortBy(values);
+            const q1 = quantileSorted(sorted, 0.25);
+            const median = quantileSorted(sorted, 0.5);
+            const q3 = quantileSorted(sorted, 0.75);
+            // Tukey whiskers: extend to the most extreme value within 1.5*IQR;
+            // anything beyond stays as an outlier scatter point.
+            const iqr = q3 - q1;
+            const lowFence = q1 - 1.5 * iqr;
+            const highFence = q3 + 1.5 * iqr;
+            const whiskerLow = sorted.find(v => v >= lowFence) ?? sorted[0];
+            let whiskerHigh = sorted[0];
+            for (const v of sorted) {
+                if (v <= highFence) {
+                    whiskerHigh = v;
+                }
+            }
             return {
-                x: symbol,
-                min: sorted.length ? sorted[0] : 0,
-                q1: quantileSorted(sorted, 0.25),
-                median: quantileSorted(sorted, 0.5),
-                q3: quantileSorted(sorted, 0.75),
-                max: sorted.length ? sorted[sorted.length - 1] : 0,
-                n: sorted.length,
+                x: rowIndex + 1,
+                min: this.clamp(whiskerLow),
+                q1: this.clamp(q1),
+                median: this.clamp(median),
+                q3: this.clamp(q3),
+                max: this.clamp(whiskerHigh),
             };
-        }).filter(box => box.n > 0);
+        });
+    }
+
+    @computed get cohortPoints(): IPoint[] {
+        return this.pointsFor(false);
+    }
+
+    @computed get patientPoints(): IPoint[] {
+        return this.pointsFor(true);
+    }
+
+    private pointsFor(patient: boolean): IPoint[] {
+        const byEntrez = _.groupBy(
+            this.props.store.mrnaExpressionDataForGenes.result,
+            d => d.entrezGeneId
+        );
+        const points: IPoint[] = [];
+        this.genes.forEach((gene, rowIndex) => {
+            (byEntrez[gene.entrezGeneId] || []).forEach(d => {
+                const isPatient = this.patientSampleIds.has(d.sampleId);
+                if (isPatient !== patient) {
+                    return;
+                }
+                const offset = patient
+                    ? 0
+                    : (hash01(d.sampleId + ':' + d.entrezGeneId) - 0.5) *
+                      2 *
+                      BOX_BAND;
+                // value on x, gene row on y (manual horizontal layout)
+                points.push({
+                    x: this.clamp(d.value),
+                    y: rowIndex + 1 + offset,
+                });
+            });
+        });
+        return points;
+    }
+
+    // Box drawn manually as line segments in (x=value, y=geneRow) space so it
+    // stays consistent with the scatter; VictoryBoxPlot's horizontal mode
+    // mis-scales its category against the log value axis.
+    @computed get boxLines(): JSX.Element[] {
+        const h = 0.28;
+        const stroke = '#333333';
+        const els: JSX.Element[] = [];
+        this.boxData.forEach(box => {
+            const row = box.x;
+            const seg = (key: string, a: IPoint, b: IPoint, width: number) =>
+                els.push(
+                    <VictoryLine
+                        key={key}
+                        data={[a, b]}
+                        style={{ data: { stroke, strokeWidth: width } }}
+                    />
+                );
+            // whisker min -> max
+            seg(`w${row}`, { x: box.min, y: row }, { x: box.max, y: row }, 1);
+            // IQR box outline
+            seg(
+                `t${row}`,
+                { x: box.q1, y: row + h },
+                { x: box.q3, y: row + h },
+                1
+            );
+            seg(
+                `bt${row}`,
+                { x: box.q1, y: row - h },
+                { x: box.q3, y: row - h },
+                1
+            );
+            seg(
+                `l${row}`,
+                { x: box.q1, y: row - h },
+                { x: box.q1, y: row + h },
+                1
+            );
+            seg(
+                `r${row}`,
+                { x: box.q3, y: row - h },
+                { x: box.q3, y: row + h },
+                1
+            );
+            // median
+            seg(
+                `m${row}`,
+                { x: box.median, y: row - h },
+                { x: box.median, y: row + h },
+                1.8
+            );
+        });
+        return els;
+    }
+
+    @computed get valueDomain(): [number, number] {
+        const vals = this.allValues;
+        const min = _.min(vals) ?? 0;
+        const max = _.max(vals) ?? 1;
+        if (this.useLog) {
+            // pad in log space so the data fills the axis; floor at smallest
+            // positive value so clamped zeros sit just inside the left edge
+            const logMin = Math.log10(this.logFloor);
+            const logMax = Math.log10(max);
+            const pad = Math.max((logMax - logMin) * 0.05, 0.02);
+            return [Math.pow(10, logMin - pad), Math.pow(10, logMax + pad)];
+        }
+        const pad = (max - min) * 0.05 || 1;
+        return [min - pad, max + pad];
+    }
+
+    // 1-2-5 ticks per decade across the value domain (clean even when the
+    // range spans less than a full decade).
+    @computed get valueTicks(): number[] | undefined {
+        if (!this.useLog) {
+            return undefined;
+        }
+        const [lo, hi] = this.valueDomain;
+        const ticks: number[] = [];
+        const startExp = Math.floor(Math.log10(lo));
+        const endExp = Math.ceil(Math.log10(hi));
+        for (let e = startExp; e <= endExp; e++) {
+            [1, 2, 5].forEach(m => {
+                const v = m * Math.pow(10, e);
+                if (v >= lo && v <= hi) {
+                    ticks.push(v);
+                }
+            });
+        }
+        return ticks.length ? ticks : undefined;
+    }
+
+    @computed get cohortName(): string {
+        const { store } = this.props;
+        const study = store.studies.result && store.studies.result[0];
+        return study ? study.name : store.studyId;
     }
 
     render() {
         const { store } = this.props;
+        return (
+            <div
+                className="mrnaTabContent"
+                style={{ padding: 20, maxWidth: 760 }}
+            >
+                <div
+                    style={{ maxWidth: 460, marginLeft: 70, marginBottom: 16 }}
+                >
+                    <label
+                        style={{
+                            fontSize: 12,
+                            fontWeight: 'bold',
+                            display: 'block',
+                            marginBottom: 4,
+                        }}
+                    >
+                        Genes
+                    </label>
+                    <ReactSelect
+                        isMulti
+                        isLoading={store.mrnaTabAllGenes.isPending}
+                        options={this.filteredGeneOptions}
+                        value={this.selectedGeneOptions}
+                        placeholder="Add genes…"
+                        closeMenuOnSelect={false}
+                        filterOption={() => true}
+                        onInputChange={(input: string) =>
+                            this.setGeneQuery(input)
+                        }
+                        noOptionsMessage={() =>
+                            this.geneQuery
+                                ? 'No matching genes'
+                                : 'Type to search genes'
+                        }
+                        onChange={(selected: any) =>
+                            store.setMrnaTabGeneSymbols(
+                                (selected || []).map(
+                                    (o: IGeneOption) => o.value
+                                )
+                            )
+                        }
+                    />
+                </div>
+                {this.renderChart()}
+            </div>
+        );
+    }
 
-        if (store.mrnaExpressionDataForGenes.isPending) {
+    private renderChart() {
+        const { store } = this.props;
+
+        if (
+            store.mrnaExpressionDataForGenes.isPending ||
+            store.mrnaTabGenes.isPending
+        ) {
             return <LoadingIndicator isLoading={true} size="big" center />;
         }
 
         const profile = store.mrnaExpressionMolecularProfile.result;
-        if (!profile || this.boxData.length === 0) {
+        if (!profile || this.genes.length === 0) {
             return (
-                <div style={{ padding: 20 }}>
-                    No mRNA expression data is available for this study.
+                <div style={{ padding: '10px 0' }}>
+                    No mRNA expression data is available for the selected genes.
                 </div>
             );
         }
 
+        const n = this.genes.length;
+        const height = 140 + n * 70;
+        const valueLabel = profile.name;
+
         return (
-            <div style={{ padding: 20 }}>
-                <h4>mRNA expression — {profile.name}</h4>
-                <VictoryChart
-                    height={400}
-                    width={600}
-                    domainPadding={{ x: 60, y: 20 }}
-                    padding={{ top: 20, bottom: 50, left: 70, right: 20 }}
+            <>
+                <div
+                    style={{
+                        fontSize: 16,
+                        fontWeight: 'bold',
+                        marginLeft: 70,
+                        marginBottom: -10,
+                    }}
                 >
+                    {valueLabel} - {this.cohortName}
+                </div>
+                <VictoryChart
+                    height={height}
+                    width={720}
+                    domain={{ x: this.valueDomain, y: [0, n + 0.5] }}
+                    domainPadding={{ y: [0, 18] }}
+                    padding={{ top: 20, bottom: 80, left: 70, right: 25 }}
+                    scale={{ x: this.useLog ? 'log' : 'linear', y: 'linear' }}
+                >
+                    {/* expression value (x) */}
                     <VictoryAxis
-                        label="Gene"
-                        axisLabelComponent={<VictoryLabel dy={10} />}
+                        label={valueLabel}
+                        tickValues={this.valueTicks}
+                        style={{
+                            axis: { stroke: '#cccccc' },
+                            grid: { stroke: '#ededed', strokeWidth: 1 },
+                            tickLabels: { fontSize: 11, fill: '#333333' },
+                            axisLabel: { fontSize: 12, padding: 36 },
+                        }}
+                        tickFormat={(t: number) =>
+                            t >= 1 ? Number(t).toLocaleString('en-US') : `${t}`
+                        }
                     />
+                    {/* gene rows (y) */}
                     <VictoryAxis
                         dependentAxis
-                        label={profile.name}
-                        axisLabelComponent={<VictoryLabel dy={-45} />}
-                    />
-                    <VictoryBoxPlot
-                        boxWidth={40}
-                        data={this.boxData}
+                        tickValues={this.genes.map((g, i) => i + 1)}
+                        tickFormat={this.genes.map(g => g.symbol)}
                         style={{
-                            min: { stroke: '#2986e2' },
-                            max: { stroke: '#2986e2' },
-                            q1: { fill: '#2986e2', fillOpacity: 0.6 },
-                            q3: { fill: '#2986e2', fillOpacity: 0.6 },
-                            median: { stroke: '#ffffff', strokeWidth: 2 },
+                            axis: { stroke: '#cccccc' },
+                            grid: { stroke: '#ededed', strokeWidth: 1 },
+                            tickLabels: { fontSize: 11, fill: '#333333' },
+                        }}
+                    />
+                    {/* cohort (FALSE) */}
+                    <VictoryScatter
+                        data={this.cohortPoints}
+                        size={2}
+                        style={{
+                            data: { fill: '#9e9e9e', fillOpacity: 0.25 },
+                        }}
+                    />
+                    {/* distribution (boxes drawn as line segments) */}
+                    {this.boxLines}
+                    {/* this patient */}
+                    <VictoryScatter
+                        data={this.patientPoints}
+                        size={8}
+                        style={{
+                            data: {
+                                fill: RED,
+                                stroke: '#ffffff',
+                                strokeWidth: 0.5,
+                            },
                         }}
                     />
                 </VictoryChart>
-            </div>
+            </>
         );
     }
 }

--- a/src/pages/patientView/mrna/MrnaTabContent.tsx
+++ b/src/pages/patientView/mrna/MrnaTabContent.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import _ from 'lodash';
 import { observer } from 'mobx-react';
-import {
-    action,
-    computed,
-    IReactionDisposer,
-    makeObservable,
-    observable,
-    reaction,
-} from 'mobx';
+import { action, computed, makeObservable, observable } from 'mobx';
 import {
     VictoryAxis,
     VictoryChart,
@@ -76,30 +69,12 @@ export default class MrnaTabContent extends React.Component<
     IMrnaTabContentProps,
     {}
 > {
-    private logDisposer: IReactionDisposer | undefined;
     private svgContainer: SVGElement | null = null;
     private getSvg = () => this.svgContainer;
 
     constructor(props: IMrnaTabContentProps) {
         super(props);
         makeObservable(this);
-    }
-
-    componentDidMount() {
-        const { store } = this.props;
-        this.logDisposer = reaction(
-            () => store.mrnaExpressionDataForGenes.isComplete,
-            isComplete => {
-                if (isComplete) {
-                    console.log(store.mrnaExpressionDataForGenes.result);
-                }
-            },
-            { fireImmediately: true }
-        );
-    }
-
-    componentWillUnmount() {
-        this.logDisposer?.();
     }
 
     // Gene symbols that actually have data, in selected order, with row index.

--- a/src/pages/patientView/mrna/MrnaTabContent.tsx
+++ b/src/pages/patientView/mrna/MrnaTabContent.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import _ from 'lodash';
+import { observer } from 'mobx-react';
+import { computed, IReactionDisposer, makeObservable, reaction } from 'mobx';
+import {
+    VictoryAxis,
+    VictoryBoxPlot,
+    VictoryChart,
+    VictoryLabel,
+} from 'victory';
+import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
+import {
+    MRNA_TAB_GENES,
+    PatientViewPageStore,
+} from 'pages/patientView/clinicalInformation/PatientViewPageStore';
+
+interface IMrnaTabContentProps {
+    store: PatientViewPageStore;
+}
+
+interface IBoxDatum {
+    x: string;
+    min: number;
+    q1: number;
+    median: number;
+    q3: number;
+    max: number;
+    n: number;
+}
+
+// Linear-interpolation quantile over an already-sorted ascending array.
+function quantileSorted(sorted: number[], q: number): number {
+    if (sorted.length === 0) {
+        return 0;
+    }
+    const pos = (sorted.length - 1) * q;
+    const base = Math.floor(pos);
+    const rest = pos - base;
+    const next = sorted[base + 1];
+    return next !== undefined
+        ? sorted[base] + rest * (next - sorted[base])
+        : sorted[base];
+}
+
+@observer
+export default class MrnaTabContent extends React.Component<
+    IMrnaTabContentProps,
+    {}
+> {
+    private logDisposer: IReactionDisposer | undefined;
+
+    constructor(props: IMrnaTabContentProps) {
+        super(props);
+        makeObservable(this);
+    }
+
+    componentDidMount() {
+        const { store } = this.props;
+        this.logDisposer = reaction(
+            () => store.mrnaExpressionDataForGenes.isComplete,
+            isComplete => {
+                if (isComplete) {
+                    console.log(store.mrnaExpressionDataForGenes.result);
+                }
+            },
+            { fireImmediately: true }
+        );
+    }
+
+    componentWillUnmount() {
+        this.logDisposer?.();
+    }
+
+    @computed get boxData(): IBoxDatum[] {
+        const { store } = this.props;
+        const dataByEntrez = _.groupBy(
+            store.mrnaExpressionDataForGenes.result,
+            d => d.entrezGeneId
+        );
+        // One box per gene, preserving MRNA_TAB_GENES order.
+        return MRNA_TAB_GENES.map(symbol => {
+            const gene = store.mrnaTabGenes.result.find(
+                g => g.hugoGeneSymbol.toUpperCase() === symbol.toUpperCase()
+            );
+            const values = gene
+                ? (dataByEntrez[gene.entrezGeneId] || [])
+                      .map(d => d.value)
+                      .filter(v => v !== null && !isNaN(v))
+                : [];
+            const sorted = _.sortBy(values);
+            return {
+                x: symbol,
+                min: sorted.length ? sorted[0] : 0,
+                q1: quantileSorted(sorted, 0.25),
+                median: quantileSorted(sorted, 0.5),
+                q3: quantileSorted(sorted, 0.75),
+                max: sorted.length ? sorted[sorted.length - 1] : 0,
+                n: sorted.length,
+            };
+        }).filter(box => box.n > 0);
+    }
+
+    render() {
+        const { store } = this.props;
+
+        if (store.mrnaExpressionDataForGenes.isPending) {
+            return <LoadingIndicator isLoading={true} size="big" center />;
+        }
+
+        const profile = store.mrnaExpressionMolecularProfile.result;
+        if (!profile || this.boxData.length === 0) {
+            return (
+                <div style={{ padding: 20 }}>
+                    No mRNA expression data is available for this study.
+                </div>
+            );
+        }
+
+        return (
+            <div style={{ padding: 20 }}>
+                <h4>mRNA expression — {profile.name}</h4>
+                <VictoryChart
+                    height={400}
+                    width={600}
+                    domainPadding={{ x: 60, y: 20 }}
+                    padding={{ top: 20, bottom: 50, left: 70, right: 20 }}
+                >
+                    <VictoryAxis
+                        label="Gene"
+                        axisLabelComponent={<VictoryLabel dy={10} />}
+                    />
+                    <VictoryAxis
+                        dependentAxis
+                        label={profile.name}
+                        axisLabelComponent={<VictoryLabel dy={-45} />}
+                    />
+                    <VictoryBoxPlot
+                        boxWidth={40}
+                        data={this.boxData}
+                        style={{
+                            min: { stroke: '#2986e2' },
+                            max: { stroke: '#2986e2' },
+                            q1: { fill: '#2986e2', fillOpacity: 0.6 },
+                            q3: { fill: '#2986e2', fillOpacity: 0.6 },
+                            median: { stroke: '#ffffff', strokeWidth: 2 },
+                        }}
+                    />
+                </VictoryChart>
+            </div>
+        );
+    }
+}

--- a/src/pages/patientView/mrna/MrnaTabContent.tsx
+++ b/src/pages/patientView/mrna/MrnaTabContent.tsx
@@ -15,8 +15,10 @@ import {
     VictoryLine,
     VictoryScatter,
 } from 'victory';
+import { CBIOPORTAL_VICTORY_THEME } from 'cbioportal-frontend-commons';
 import ReactSelect from 'react-select';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
+import ChartContainer from 'shared/components/ChartContainer/ChartContainer';
 import { PatientViewPageStore } from 'pages/patientView/clinicalInformation/PatientViewPageStore';
 
 interface IGeneOption {
@@ -75,6 +77,8 @@ export default class MrnaTabContent extends React.Component<
     {}
 > {
     private logDisposer: IReactionDisposer | undefined;
+    private svgContainer: SVGElement | null = null;
+    private getSvg = () => this.svgContainer;
 
     constructor(props: IMrnaTabContentProps) {
         super(props);
@@ -361,6 +365,12 @@ export default class MrnaTabContent extends React.Component<
         return study ? study.name : store.studyId;
     }
 
+    @computed get chartTitle(): string {
+        const profile = this.props.store.mrnaExpressionMolecularProfile.result;
+        const label = profile ? profile.name : 'mRNA expression';
+        return `${label} - ${this.cohortName}`;
+    }
+
     render() {
         const { store } = this.props;
         return (
@@ -368,9 +378,10 @@ export default class MrnaTabContent extends React.Component<
                 className="mrnaTabContent"
                 style={{ padding: 20, maxWidth: 760 }}
             >
-                <div
-                    style={{ maxWidth: 460, marginLeft: 70, marginBottom: 16 }}
-                >
+                <h3 style={{ marginTop: 0, marginBottom: 16 }}>
+                    {this.chartTitle}
+                </h3>
+                <div style={{ maxWidth: 460, marginBottom: 16 }}>
                     <label
                         style={{
                             fontSize: 12,
@@ -435,51 +446,45 @@ export default class MrnaTabContent extends React.Component<
         const valueLabel = profile.name;
 
         return (
-            <>
-                <div
-                    style={{
-                        fontSize: 16,
-                        fontWeight: 'bold',
-                        marginLeft: 70,
-                        marginBottom: -10,
-                    }}
-                >
-                    {valueLabel} - {this.cohortName}
-                </div>
+            <ChartContainer
+                getSVGElement={this.getSvg}
+                exportFileName={`mrna_expression_${this.cohortName}`}
+            >
                 <VictoryChart
+                    theme={CBIOPORTAL_VICTORY_THEME}
                     height={height}
                     width={720}
                     domain={{ x: this.valueDomain, y: [0, n + 0.5] }}
                     domainPadding={{ y: [0, 18] }}
                     padding={{ top: 20, bottom: 80, left: 70, right: 25 }}
-                    scale={{ x: this.useLog ? 'log' : 'linear', y: 'linear' }}
+                    scale={{
+                        x: this.useLog ? 'log' : 'linear',
+                        y: 'linear',
+                    }}
+                    containerComponent={
+                        <svg
+                            ref={(el: SVGSVGElement | null) => {
+                                this.svgContainer = el;
+                            }}
+                        />
+                    }
                 >
                     {/* expression value (x) */}
                     <VictoryAxis
                         label={valueLabel}
                         tickValues={this.valueTicks}
-                        style={{
-                            axis: { stroke: '#cccccc' },
-                            grid: { stroke: '#ededed', strokeWidth: 1 },
-                            tickLabels: { fontSize: 11, fill: '#333333' },
-                            axisLabel: { fontSize: 12, padding: 36 },
-                        }}
                         tickFormat={(t: number) =>
                             t >= 1 ? Number(t).toLocaleString('en-US') : `${t}`
                         }
+                        style={{ axisLabel: { padding: 38 } }}
                     />
                     {/* gene rows (y) */}
                     <VictoryAxis
                         dependentAxis
                         tickValues={this.genes.map((g, i) => i + 1)}
                         tickFormat={this.genes.map(g => g.symbol)}
-                        style={{
-                            axis: { stroke: '#cccccc' },
-                            grid: { stroke: '#ededed', strokeWidth: 1 },
-                            tickLabels: { fontSize: 11, fill: '#333333' },
-                        }}
                     />
-                    {/* cohort (FALSE) */}
+                    {/* cohort */}
                     <VictoryScatter
                         data={this.cohortPoints}
                         size={2}
@@ -502,7 +507,7 @@ export default class MrnaTabContent extends React.Component<
                         }}
                     />
                 </VictoryChart>
-            </>
+            </ChartContainer>
         );
     }
 }


### PR DESCRIPTION
## Summary
Adds a new **MRNA** tab to the patient view that visualizes mRNA expression for a chosen set of genes across all samples in the patient's study.

- New `MrnaTabContent` component rendering a horizontal boxplot (built directly on Victory) — one box per gene, log scale for non-negative data (TPM/RSEM), Tukey whiskers, jittered cohort points, and a larger red dot marking the current patient's sample.
- Gene chooser via React Select, backed by the genes endpoint (`getAllGenesUsingGET`) loaded with `remoteData`; options are pre-filtered/capped to 50 so the ~20k-gene list doesn't freeze the UI.
- Data loaded reactively in `PatientViewPageStore` (`mrnaTabGeneSymbols` selection → `mrnaTabGenes` → `mrnaExpressionDataForGenes`), scoped to all samples in the study.
- Chart wrapped in `ChartContainer` (download control) and styled with `CBIOPORTAL_VICTORY_THEME`; title rendered as an `h3` above the selector.

## Notes
- The store selects the first `MRNA_EXPRESSION` molecular profile in the study; for studies whose first such profile is miRNA/z-scores this may not be the ideal gene-level profile (follow-up).
- `MrnaTabContent` still contains a debug `console.log` of the loaded data in `componentDidMount` — should be removed before any upstream PR.

## Test plan
- [ ] Open a patient in a study with an mRNA expression profile; confirm the **MRNA** tab renders the boxplot with TP53/EGFR/KRAS by default.
- [ ] Add/remove genes via the chooser and confirm the chart updates reactively.
- [ ] Confirm typing in the gene box stays responsive (no freeze).
- [ ] Confirm a study with no mRNA profile shows the empty-state message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
